### PR TITLE
[bugfix] remove initssdnand and rearrange code

### DIFF
--- a/SSD/fileIOStream.h
+++ b/SSD/fileIOStream.h
@@ -4,11 +4,14 @@
 #include <iomanip>
 #include <sstream>
 #include <iostream>
-#include <string>
 #include <vector>
 
-using namespace std;
 using std::string;
+using std::vector;
+using std::string;
+using std::ofstream;
+using std::istringstream;
+using std::ifstream;
 using std::cout;
 
 class IoStream {
@@ -18,7 +21,6 @@ public:
     output_file_name = "ssd_output.txt";
     storageSize = size;
     buffer = buf;
-    initSsdNand();
   };
   string readFileAsString(const string &filename);
   void writeError();
@@ -38,7 +40,7 @@ public:
 
 private:
   int storageSize = 0;
-  unsigned long *buffer ;
+  unsigned long *buffer;
   bool isValid_nand_file = true;
   bool isValid_output_file = true;
 };

--- a/SSD/fileIOstream.cpp
+++ b/SSD/fileIOstream.cpp
@@ -6,7 +6,7 @@ void IoStream::writeError() {
 }
 
 void IoStream::clearOutput() {
-  ofstream ofs(output_file_name, ios::trunc); // 빈 파일로 만듦
+  ofstream ofs(output_file_name, std::ios::trunc); // 빈 파일로 만듦
 }
 
 string IoStream::readFileAsString(const string &filename) {
@@ -24,12 +24,14 @@ string IoStream::readFileAsString(const string &filename) {
 void IoStream::initSsdNand() {
   ofstream ofs(nand_file_name);
   if (!ofs) {
-    cerr << "file create fail : " << nand_file_name << endl;
+    std::cerr << "file create fail : " << nand_file_name << std::endl;
     return;
   }
 
   for (int i = 0; i < storageSize; ++i) {
-    ofs << dec << i << " 0x" << setfill('0') << setw(8) << hex << uppercase << 0
+    ofs << std::dec << i << " 0x" << std::setfill('0') << std::setw(8)
+        << std::hex << std::uppercase
+        << 0
         << "\n";
   }
 }

--- a/SSD/ssdDriver.cpp
+++ b/SSD/ssdDriver.cpp
@@ -1,18 +1,10 @@
 #include "device.h"
 #include "fileIOStream.h"
 
-using std::ofstream;
-#include <string>
-#include <vector>
-
-using std::string;
-using std::vector;
-
 class SSDDriver : public Device {
 public:
   SSDDriver() {
     stream = new IoStream(MAX_NAND_MEMORY_MAP_SIZE, buf);
-    stream->initSsdNand();
   }
   void run(int argc, char *argv[]) {
     vector<string> params = parseParams(argc, argv);
@@ -45,32 +37,34 @@ public:
       return false;
   }
   bool read(int lba) override {
-    stream->loadNandFile();
-
     if (!isValid_LBA_Range(lba)) {
       stream->writeError();
       return false;
     }
 
-    ofstream ofs = stream->getOutputWriteStream();
+    stream->loadNandFile();
 
-    ofs << "0x" << setfill('0') << setw(8) << hex << uppercase << buf[lba];
+    ofstream ofs = stream->getOutputWriteStream();
+    ofs << "0x" << std::setfill('0') << std::setw(8) << std::hex
+        << std::uppercase
+        << buf[lba];
 
     return true;
   }
   bool write(int lba, unsigned long value) override {
-    stream->loadNandFile();
-
     if (!isValid_LBA_Range(lba)) {
       stream->writeError();
       return false;
     }
+
+    stream->loadNandFile();
 
     buf[lba] = value;
 
     ofstream ofs = stream->getNandWriteStream();
     for (int i = 0; i < MAX_NAND_MEMORY_MAP_SIZE; ++i) {
-      ofs << dec << i << " 0x" << setfill('0') << setw(8) << hex << uppercase
+      ofs << std::dec << i << " 0x" << std::setfill('0') << std::setw(8)
+          << std::hex << std::uppercase
           << buf[i] << "\n";
     }
 


### PR DESCRIPTION
## 📝 배경
> 어떤 기능이나 문제를 해결했나요?
- SSD.exe 부를 때마다 initnandssd가 불려 sdd_nand.txt가 clear되는 현상이 있어 생성자에서 이부분 삭제했습니다.

## 📝 세부 사항
> 세부 사항을 기록해주세요.
- 삭제하면서 usingnamespace std도 삭제 진행하였습니다.

## ✅ 체크리스트
다음 항목을 모두 만족하는 지 한번 더 확인 해주세요.
- [x] 코드 스타일 가이드에 맞게 작성함 (LLVM)
- [x] 최신 master를 merge하여 conflict를 해결함
- [x] 유닛 테스트를 모두 통과함
- [x] 배경 및 세부 사항을 적절히 기술함
