### PR TITLE
Feature/ssd exe

### DIFF
--- a/Testshell/SSD_EXE.cpp
+++ b/Testshell/SSD_EXE.cpp
@@ -1,0 +1,82 @@
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <direct.h>
+
+using std::string;
+
+class SSD_INTERFACE {
+public:
+  virtual void read(int lba) = 0;
+  virtual void write(int lba, unsigned long value) = 0;
+  virtual string getResult() = 0;
+};
+
+class SSD_EXE : public SSD_INTERFACE {
+public:
+  SSD_EXE() : ssdDir(getSSDExePath()) {}
+
+  void read(int lba) override {
+    std::ostringstream cmd;
+    cmd << "\"" << ssdDir << "\\ssd.exe\" R " << lba;
+    int ret = system(cmd.str().c_str());
+
+    if (ret != 0) {
+      lastResult = "ERROR";
+    } else {
+      lastResult = readOutputFile();
+    }
+  }
+
+  void write(int lba, unsigned long value) override {
+    std::ostringstream cmd;
+    cmd << "\"" << ssdDir << "\\ssd.exe\" W " << lba << " 0x" << std::hex
+        << value;
+    int ret = system(cmd.str().c_str());
+
+    if (ret != 0) {
+      lastResult = "ERROR";
+    } else {
+      string out = readOutputFile();
+      lastResult = out.empty() ? "" : "ERROR";
+    }
+  }
+
+  string getResult() override { return lastResult; }
+
+private:
+  string ssdDir;
+  string lastResult;
+
+  // 현재 디렉토리 기준 ../SSD/x64/Release 를 절대경로로 변환
+  string getSSDExePath() {
+    char cwd[1024];
+    if (!_getcwd(cwd, sizeof(cwd))) {
+      std::cerr << "[ERROR] 현재 경로를 얻을 수 없습니다." << std::endl;
+      std::exit(1);
+    }
+
+    std::string relPath = std::string(cwd) + "\\..\\SSD\\x64\\Release";
+    char absPath[1024];
+    if (!_fullpath(absPath, relPath.c_str(), sizeof(absPath))) {
+      std::cerr << "[ERROR] 절대 경로 변환 실패." << std::endl;
+      std::exit(1);
+    }
+
+    return std::string(absPath);
+  }
+
+  string readOutputFile() {
+    std::ifstream infile(ssdDir + "\\ssd_output.txt");
+    if (!infile.is_open()) {
+      return "ERROR";
+    }
+
+    std::string line;
+    if (std::getline(infile, line)) {
+      return line;
+    }
+
+    return "";
+  }
+};

--- a/Testshell/SSD_EXE.cpp
+++ b/Testshell/SSD_EXE.cpp
@@ -19,19 +19,25 @@ public:
   void read(int lba) override {
     std::ostringstream cmd;
     cmd << "\"" << ssdDir << "\\ssd.exe\" R " << lba;
+#ifdef _DEBUG
+    std::cout << cmd.str() << "\n";
+#else
     int ret = system(cmd.str().c_str());
-
     if (ret != 0) {
       lastResult = "ERROR";
     } else {
       lastResult = readOutputFile();
     }
+#endif
   }
 
   void write(int lba, unsigned long value) override {
     std::ostringstream cmd;
     cmd << "\"" << ssdDir << "\\ssd.exe\" W " << lba << " 0x" << std::hex
-        << value;
+        << std::uppercase << value;
+#ifdef _DEBUG
+    std::cout << cmd.str();
+#else
     int ret = system(cmd.str().c_str());
 
     if (ret != 0) {
@@ -40,6 +46,7 @@ public:
       string out = readOutputFile();
       lastResult = out.empty() ? "" : "ERROR";
     }
+#endif
   }
 
   string getResult() override { return lastResult; }
@@ -48,7 +55,7 @@ private:
   string ssdDir;
   string lastResult;
 
-  // 현재 디렉토리 기준 ../SSD/x64/Release 를 절대경로로 변환
+  // 현재 디렉토리 기준 ../../../SSD/x64/Release 를 절대경로로 변환
   string getSSDExePath() {
     char cwd[1024];
     if (!_getcwd(cwd, sizeof(cwd))) {

--- a/Testshell/SSD_EXE_test.cpp
+++ b/Testshell/SSD_EXE_test.cpp
@@ -1,0 +1,31 @@
+#include "SSD_EXE.cpp"
+#include "gmock/gmock.h"
+
+//class MockSSD_EXE : public SSD_EXE {
+//public:
+//  MOCK_METHOD(void, read, (int lba), ());
+//  MOCK_METHOD(void, write, (int lba, unsigned long value), ());
+//  MOCK_METHOD(std::string, getResult, (), ());
+//};
+
+TEST(SSDEXE, readNormal) {
+  using testing::internal::CaptureStdout;
+  using testing::internal::GetCapturedStdout;
+  SSD_EXE ssd;
+
+  CaptureStdout();
+  ssd.read(0);
+  std::string output = GetCapturedStdout();
+  EXPECT_TRUE(output.find("ssd.exe\" R 0") != std::string::npos);
+}
+
+TEST(SSDEXE, writeNormal) {
+  using testing::internal::CaptureStdout;
+  using testing::internal::GetCapturedStdout;
+  SSD_EXE ssd;
+
+  CaptureStdout();
+  ssd.write(0, 0xAAAABBBB);
+  std::string output = GetCapturedStdout();
+  EXPECT_TRUE(output.find("ssd.exe\" W 0xAAAABBBB") != std::string::npos);
+}

--- a/Testshell/SSD_EXE_test.cpp
+++ b/Testshell/SSD_EXE_test.cpp
@@ -1,31 +1,25 @@
 #include "SSD_EXE.cpp"
 #include "gmock/gmock.h"
+using testing::internal::CaptureStdout;
+using testing::internal::GetCapturedStdout;
 
-//class MockSSD_EXE : public SSD_EXE {
-//public:
-//  MOCK_METHOD(void, read, (int lba), ());
-//  MOCK_METHOD(void, write, (int lba, unsigned long value), ());
-//  MOCK_METHOD(std::string, getResult, (), ());
-//};
-
-TEST(SSDEXE, readNormal) {
-  using testing::internal::CaptureStdout;
-  using testing::internal::GetCapturedStdout;
+class SSDEXEFixture : public ::testing::Test {
+public:
   SSD_EXE ssd;
+};
 
+TEST_F(SSDEXEFixture, readNormal) {
   CaptureStdout();
   ssd.read(0);
   std::string output = GetCapturedStdout();
-  EXPECT_TRUE(output.find("ssd.exe\" R 0") != std::string::npos);
+  EXPECT_TRUE(output.find("ssd.exe\" R 0") != std::string::npos)
+	  << "Actual stream : " << output;
 }
 
-TEST(SSDEXE, writeNormal) {
-  using testing::internal::CaptureStdout;
-  using testing::internal::GetCapturedStdout;
-  SSD_EXE ssd;
-
+TEST_F(SSDEXEFixture, writeNormal) {
   CaptureStdout();
   ssd.write(0, 0xAAAABBBB);
   std::string output = GetCapturedStdout();
-  EXPECT_TRUE(output.find("ssd.exe\" W 0xAAAABBBB") != std::string::npos);
+  EXPECT_TRUE(output.find("ssd.exe\" W 0 0xAAAABBBB") != std::string::npos)
+      << "Actual stream : " << output;
 }

--- a/Testshell/Testshell.vcxproj
+++ b/Testshell/Testshell.vcxproj
@@ -132,6 +132,8 @@
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'"> %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'"> %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
+    <ClCompile Include="SSD_EXE.cpp" />
+    <ClCompile Include="SSD_EXE_test.cpp" />
     <ClCompile Include="test_shell.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Testshell/Testshell.vcxproj.filters
+++ b/Testshell/Testshell.vcxproj.filters
@@ -30,5 +30,11 @@
     <ClCompile Include="test_shell.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="SSD_EXE.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="SSD_EXE_test.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/Testshell/test_shell.cpp
+++ b/Testshell/test_shell.cpp
@@ -1,4 +1,5 @@
 #include "gmock/gmock.h"
+#include "SSD_EXE.cpp"
 
 #include <iostream>
 #include <string>
@@ -11,13 +12,6 @@ using std::vector;
 
 struct ShellExit : public std::exception {
   const char *what() const noexcept override { return "Shell exited."; }
-};
-
-class SSD_INTERFACE {
-public:
-  virtual void read(int lba) = 0;
-  virtual void write(int lba, unsigned long value) = 0;
-  virtual string getResult() = 0;
 };
 
 // MockDriver


### PR DESCRIPTION
## 📝 배경
> 어떤 기능이나 문제를 해결했나요?
- TestShell 에서 ssd.exe 를 호출하는 class 구현

## 📝 세부 사항
> 세부 사항을 기록해주세요.
- SSD_EXE : ssd.exe 와 ssd_output.txt 의 경로를 알고 있음.
- read : ```abspath{ssd.exe} R 0``` 을 시스템 명령어로 호출하여 ssd.exe 에게 read 를 전달함
- write : ```abspath{ssd.exe} W 0 0xAAAABBBB``` 을 시스템 명령어로 호출하여 ssd.exe 에게 read 를 전달함

## ✅ 체크리스트
다음 항목을 모두 만족하는 지 한번 더 확인 해주세요.
- [x] 코드 스타일 가이드에 맞게 작성함 (LLVM)
- [x] 최신 master를 merge하여 conflict를 해결함
- [x] 유닛 테스트를 모두 통과함
- [x] 배경 및 세부 사항을 적절히 기술함
