### PR TITLE
[Feature] BufferControl - 초기 init시 기존 buffer 참조할 수 있도록 설정 

### DIFF
--- a/SSD/ssd_cmd_buffer.cpp
+++ b/SSD/ssd_cmd_buffer.cpp
@@ -1,7 +1,7 @@
 #include "ssd_cmd_buffer.h"
-#include <iostream>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 
 namespace fs = std::filesystem;
 using std::cout;
@@ -22,7 +22,9 @@ void CmdBuffer::updateCommand(const std::string &cmd) {
   fileName = (fs::path(fileName).parent_path() / cmd).string();
 }
 
-void CmdBuffer::clear() { updateCommand(std::to_string(getIndex()) + "_empty"); }
+void CmdBuffer::clear() {
+  updateCommand(std::to_string(getIndex()) + "_empty");
+}
 
 bool CmdBuffer::isEmpty() const {
   return getName().find("empty") != std::string::npos;

--- a/SSD/ssd_cmd_buffer_control.h
+++ b/SSD/ssd_cmd_buffer_control.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "ssd_cmd_buffer.h"
-#include <vector>
 #include <string>
+#include <vector>
 
 class CmdBufferControl {
 public:
@@ -10,9 +10,10 @@ public:
   std::string getBufferNameList() const;
   bool updateToNextEmpty(const std::string &cmd);
   bool updateBufferByIndex(int index, const std::string &cmd);
+  std::string setBufferName(int index, const std::string &cmd);
   bool isValidBufferIndex(int index);
   bool clearBufferByIndex(int index);
-  void clearAllBuffer(void); 
+  void clearAllBuffer(void);
   void flush();
   bool isBufferFull() const;
   const int MAX_BUFFER_SIZE = 5;

--- a/SSD/ssd_cmd_buffer_control_test.cpp
+++ b/SSD/ssd_cmd_buffer_control_test.cpp
@@ -6,39 +6,77 @@ using namespace testing;
 
 class BufferControlFixture : public Test {
 public:
-  CmdBufferControl &cmdBuffer = CmdBufferControl::getInstance    ();
-
+  void SetUp() override { cmdBuffer.clearAllBuffer(); }
+  CmdBufferControl &cmdBuffer = CmdBufferControl::getInstance();
   const std::string BUFFER_EMPTY = "1_empty,2_empty,3_empty,4_empty,5_empty,";
 };
 
 TEST_F(BufferControlFixture, BufferCheckAfterInit) {
   std::string expected_ret = BUFFER_EMPTY;
-
   EXPECT_EQ(expected_ret, cmdBuffer.getBufferNameList());
 }
 
 TEST_F(BufferControlFixture, BufferUpdateByIndexTest) {
-  std::string expected_ret = "1_empty,2_W_20_0xABCDABCD,3_empty,4_empty,5_empty,";
-  cmdBuffer.updateBufferByIndex(2, "2_W_20_0xABCDABCD");
+  std::string expected_ret =
+      "1_empty,2_W_20_0xABCDABCD,3_empty,4_empty,5_empty,";
+  cmdBuffer.updateBufferByIndex(2, "W_20_0xABCDABCD");
   EXPECT_EQ(expected_ret, cmdBuffer.getBufferNameList());
 }
 
 TEST_F(BufferControlFixture, BufferUpdateByIndex2Test) {
-  EXPECT_TRUE(cmdBuffer.updateBufferByIndex(2, "2_W_20_0xABCDABCD"));
-  EXPECT_TRUE(cmdBuffer.updateBufferByIndex(2, "2_R_10"));
+  EXPECT_TRUE(cmdBuffer.updateBufferByIndex(2, "W_20_0xABCDABCD"));
+  EXPECT_TRUE(cmdBuffer.updateBufferByIndex(2, "R_10"));
 }
 
 TEST_F(BufferControlFixture, BufferClearTest) {
   std::string expected_ret = BUFFER_EMPTY;
-  cmdBuffer.updateBufferByIndex(2, "2_W_20_0xABCDABCD");
+  cmdBuffer.updateBufferByIndex(2, "W_20_0xABCDABCD");
   cmdBuffer.clearBufferByIndex(2);
   EXPECT_EQ(expected_ret, cmdBuffer.getBufferNameList());
 }
 
-TEST_F(BufferControlFixture, BufferUpd) {
-  auto &bc = CmdBufferControl::getInstance();
+TEST_F(BufferControlFixture, BufferAllClearTest) {
   std::string expected_ret = BUFFER_EMPTY;
-  bc.updateBufferByIndex(2, "2_W_20_0xABCDABCD");
-  bc.clearBufferByIndex(2);
+  cmdBuffer.updateBufferByIndex(1, "R_20");
+  cmdBuffer.updateBufferByIndex(2, "W_20_0xABCDABCD");
+  cmdBuffer.updateBufferByIndex(3, "W_1_0xFFFFFFFF");
+  cmdBuffer.clearAllBuffer();
+  EXPECT_EQ(expected_ret, cmdBuffer.getBufferNameList());
+}
+
+TEST_F(BufferControlFixture, BufferUpdateToNextEmptyTest) {
+  std::string expected_ret = "1_R_20,2_W_20_0xABCDABCD,3_W_1_0x11112222,4_W_10_"
+                             "0xABCDABCD,5_W_99_0xBBBBAAAA,";
+  EXPECT_TRUE(cmdBuffer.updateToNextEmpty("R_20"));
+  EXPECT_TRUE(cmdBuffer.updateToNextEmpty("W_20_0xABCDABCD"));
+  EXPECT_TRUE(cmdBuffer.updateToNextEmpty("W_1_0x11112222"));
+  EXPECT_TRUE(cmdBuffer.updateToNextEmpty("W_10_0xABCDABCD"));
+  EXPECT_TRUE(cmdBuffer.updateToNextEmpty("W_99_0xBBBBAAAA"));
+  EXPECT_FALSE(cmdBuffer.updateToNextEmpty("W_99_0xBBBBAAAA"));
+  EXPECT_EQ(expected_ret, cmdBuffer.getBufferNameList());
+}
+
+TEST_F(BufferControlFixture, BufferIsFullTest) {
+  std::string expected_ret = "1_R_20,2_W_20_0xABCDABCD,3_W_1_0x11112222,4_W_10_"
+                             "0xABCDABCD,5_W_99_0xBBBBAAAA,";
+  EXPECT_TRUE(cmdBuffer.updateToNextEmpty("R_20"));
+  EXPECT_TRUE(cmdBuffer.updateToNextEmpty("W_20_0xABCDABCD"));
+  EXPECT_TRUE(cmdBuffer.updateToNextEmpty("W_1_0x11112222"));
+  EXPECT_TRUE(cmdBuffer.updateToNextEmpty("W_10_0xABCDABCD"));
+  EXPECT_TRUE(cmdBuffer.updateToNextEmpty("W_99_0xBBBBAAAA"));
+  EXPECT_FALSE(cmdBuffer.updateToNextEmpty("W_99_0xBBBBAAAA"));
+
+  EXPECT_TRUE(cmdBuffer.isBufferFull());
+  EXPECT_EQ(expected_ret, cmdBuffer.getBufferNameList());
+}
+
+TEST_F(BufferControlFixture, BufferIsNotFullTest) {
+  std::string expected_ret =
+      "1_R_20,2_W_20_0xABCDABCD,3_W_1_0x11112222,4_empty,5_empty,";
+  EXPECT_TRUE(cmdBuffer.updateToNextEmpty("R_20"));
+  EXPECT_TRUE(cmdBuffer.updateToNextEmpty("W_20_0xABCDABCD"));
+  EXPECT_TRUE(cmdBuffer.updateToNextEmpty("W_1_0x11112222"));
+
+  EXPECT_FALSE(cmdBuffer.isBufferFull());
   EXPECT_EQ(expected_ret, cmdBuffer.getBufferNameList());
 }


### PR DESCRIPTION
## 📝 배경
> 어떤 기능이나 문제를 해결했나요?
- 초기 init시 기존 Buffer 참조 할 수 있도록 설정

## 📝 세부 사항
> 세부 사항을 기록해주세요.
- Buffer는 유지하고 다시 프로그램 실행시 Buffer를 읽어온다.
- update시 buffer index는 설정하지 않고 자동으로 지정


## ✅ 체크리스트
다음 항목을 모두 만족하는 지 한번 더 확인 해주세요.
- [ ] 코드 스타일 가이드에 맞게 작성함 (LLVM)
- [ ] 최신 master를 merge하여 conflict를 해결함
- [ ] 유닛 테스트를 모두 통과함
- [ ] 배경 및 세부 사항을 적절히 기술함
