### PR TITLE
[feature] logger init and print TestShell class methods

### DIFF
--- a/Testshell/logger.cpp
+++ b/Testshell/logger.cpp
@@ -34,8 +34,11 @@ void Logger::resetInstance() {
 
 void Logger::print(const std::string &className, const std::string &message) {
   std::string timestamp = getCurrentTimestamp();
-  std::string logEntry =
-      "[" + timestamp + "] " + className + " : " + message + ".";
+  
+  std::ostringstream oss;
+  oss << "[" << timestamp << "] " << std::left << std::setw(30) << className
+      << ": " << message << ".";
+  std::string logEntry = oss.str();
 
   writeToFile(logEntry);
   checkFileRotation();

--- a/Testshell/logger_test.cpp
+++ b/Testshell/logger_test.cpp
@@ -141,7 +141,7 @@ TEST_F(LoggerTest, LogEntryFormat_CorrectTimestampAndMessage) {
   EXPECT_THAT(
       capturedLogEntry,
       ::testing::MatchesRegex(
-          R"(\[\d\d\.\d\d\.\d\d \d\d:\d\d\] TestClass : Test message\.)"));
+          R"(\[\d\d\.\d\d\.\d\d \d\d:\d\d\] TestClass\s+: Test message\.)"));
 }
 
 TEST_F(LoggerTest, FileOperationFailure_HandlesGracefully) {

--- a/Testshell/test_shell.cpp
+++ b/Testshell/test_shell.cpp
@@ -1,4 +1,3 @@
-#include "gmock/gmock.h"
 #include "ssd_exe.cpp"
 #include "test_shell.h"
 #include "command.h"
@@ -17,14 +16,6 @@ TestShell::~TestShell() {
   delete ctrl;
   delete parser;
 }
-
-// MockDriver
-class MockSSD : public SSD_INTERFACE {
-public:
-  MOCK_METHOD(void, read, (int lba), (override));
-  MOCK_METHOD(void, write, (int lba, unsigned long value), (override));
-  MOCK_METHOD(string, getResult, (), (override));
-};
 
 void TestShell::initializeCommandHandlers() {
   // Regular commands
@@ -52,7 +43,10 @@ void TestShell::run() {
     cout << "> ";
     getline(std::cin, userInput);
     command = parsing(userInput);
+    logger.print("TestShell.run()",
+        "Successfully parsed command - " + command.command);
     if (command.command == "exit") {
+      logger.print("TestShell.run()", "Exiting shell.");
       break;
     }
     executeCommand(command);
@@ -65,9 +59,13 @@ void TestShell::executeCommand(const Command &command) {
   auto commandIt = commandHandlers.find(cmd);
   if (commandIt != commandHandlers.end()) {
     commandIt->second->execute(this, command);
+    logger.print("TestShell.executeCommand()",
+        "Successfully executed command - " + cmd);
     return;
   }
   
+  logger.print("TestShell.executeCommand()",
+      "Invalid command - " + cmd);
   cout << "INVALID COMMAND" << endl;
 }
 

--- a/Testshell/test_shell.h
+++ b/Testshell/test_shell.h
@@ -6,7 +6,6 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <numeric>
 #include <random>
 
 #include "ssd_interface.h"

--- a/Testshell/test_shell.h
+++ b/Testshell/test_shell.h
@@ -6,9 +6,11 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <numeric>
 #include <random>
 
 #include "ssd_interface.h"
+#include "logger.h"
 
 using std::cout;
 using std::endl;
@@ -51,6 +53,7 @@ private:
   SSD_INTERFACE *ssd;
   Command command;
   std::unordered_map<string, std::unique_ptr<ICommandHandler>> commandHandlers;
+  Logger &logger = Logger::getInstance();
 
   const int HEX_BASE = 16;
 


### PR DESCRIPTION
## 📝 배경
> 어떤 기능이나 문제를 해결했나요?
- 구현한 로거 사용

## 📝 세부 사항
> 세부 사항을 기록해주세요.
- TestShell class의 private 변수로 logger 선언 후 바로 singleton instance 초기화
- TestShell class의 run() 함수와 executeCommand() 함수 성공 시 로그 출력
- log의 포맷을 맞추기 위한 공백 추가 및 유닛테스트 수정

## 테스트 결과
![image](https://github.com/user-attachments/assets/2c1952b9-cd9b-413e-a6c2-60ed71a084b0)

- 10KB 초과 시 분리/압축 확인
![image](https://github.com/user-attachments/assets/d00cf647-b3d2-4065-9559-cb0f67396a8a)

## ✅ 체크리스트
다음 항목을 모두 만족하는 지 한번 더 확인 해주세요.
- [x] 코드 스타일 가이드에 맞게 작성함 (LLVM)
- [x] 최신 master를 merge하여 conflict를 해결함
- [x] 유닛 테스트를 모두 통과함
- [x] 배경 및 세부 사항을 적절히 기술함
