### PR TITLE
[refactor] ssd_exe header 와 cpp 로 분리

### DIFF
--- a/Testshell/Testshell.vcxproj
+++ b/Testshell/Testshell.vcxproj
@@ -142,6 +142,7 @@
     <ClCompile Include="fullwrite_command.cpp" />
     <ClCompile Include="help_command.cpp" />
     <ClCompile Include="read_command.cpp" />
+    <ClCompile Include="ssd_exe.cpp" />
     <ClCompile Include="ssd_exe.h" />
     <ClCompile Include="ssd_exe_test.cpp" />
     <ClCompile Include="test_script_command.cpp" />

--- a/Testshell/Testshell.vcxproj.filters
+++ b/Testshell/Testshell.vcxproj.filters
@@ -16,6 +16,9 @@
     <Filter Include="소스 파일\commandHandler">
       <UniqueIdentifier>{ffb454d6-893e-4c11-8de7-4d51a690766f}</UniqueIdentifier>
     </Filter>
+    <Filter Include="소스 파일\ssd_interface">
+      <UniqueIdentifier>{9cf0abb8-9183-4b24-a9fb-f335fea76ffa}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -48,12 +51,6 @@
     <ClCompile Include="write_command.cpp">
       <Filter>소스 파일\commandHandler</Filter>
     </ClCompile>
-    <ClCompile Include="ssd_exe.cpp">
-      <Filter>소스 파일</Filter>
-    </ClCompile>
-    <ClCompile Include="ssd_exe_test.cpp">
-      <Filter>소스 파일</Filter>
-    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gtest\gtest-all.cc">
       <Filter>소스 파일</Filter>
     </ClCompile>
@@ -66,6 +63,24 @@
     <ClCompile Include="erase_range_command.cpp">
       <Filter>소스 파일\commandHandler</Filter>
     </ClCompile>
+    <ClCompile Include="file_system_interface.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="logger.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="logger_test.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="ssd_exe.h">
+      <Filter>헤더 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="ssd_exe_test.cpp">
+      <Filter>소스 파일\ssd_interface</Filter>
+    </ClCompile>
+    <ClCompile Include="ssd_exe.cpp">
+      <Filter>소스 파일\ssd_interface</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="test_shell.h">
@@ -77,5 +92,14 @@
     <ClInclude Include="ssd_interface.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
+    <ClInclude Include="file_system_interface.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="logger.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="shell_script.txt" />
   </ItemGroup>
 </Project>

--- a/Testshell/ssd_exe.cpp
+++ b/Testshell/ssd_exe.cpp
@@ -1,0 +1,78 @@
+#include "ssd_exe.h"
+
+using std::string;
+
+void SSD_EXE::read(int lba) {
+  std::ostringstream cmd;
+  cmd << "\"" << ssdDir << "\\" << SSD_EXE_NAME << "\" R " << lba;
+#ifdef _DEBUG
+  std::cout << cmd.str() << "\n";
+#else
+  int ret = system(cmd.str().c_str());
+  if (ret != 0) {
+    lastResult = ERROR_MSG;
+  } else {
+    lastResult = readOutputFile();
+  }
+#endif
+}
+
+void SSD_EXE::write(int lba, unsigned long value) {
+  std::ostringstream cmd;
+  cmd << "\"" << ssdDir << "\\" << SSD_EXE_NAME << "\" W " << lba << " 0x"
+      << std::hex << std::uppercase << value;
+#ifdef _DEBUG
+  std::cout << cmd.str() << "\n";
+#else
+  int ret = system(cmd.str().c_str());
+
+  if (ret != 0) {
+    lastResult = ERROR_MSG;
+  } else {
+    string out = readOutputFile();
+    lastResult = out.empty() ? "" : ERROR_MSG;
+  }
+#endif
+}
+
+void SSD_EXE::erase(int lba, int size) {
+  std::ostringstream cmd;
+  cmd << "\"" << ssdDir << "\\" << SSD_EXE_NAME << "\" E " << lba << " "
+      << size;
+#ifdef _DEBUG
+  std::cout << cmd.str() << "\n";
+#else
+  int ret = system(cmd.str().c_str());
+
+  if (ret != 0) {
+    lastResult = ERROR_MSG;
+  } else {
+    string out = readOutputFile();
+    lastResult = out.empty() ? "" : ERROR_MSG;
+  }
+#endif
+}
+
+string SSD_EXE::getCurWorkingDir() {
+  char cwd[1024];
+  if (!_getcwd(cwd, sizeof(cwd))) {
+    std::cerr << "[ERROR] 현재 경로를 얻을 수 없습니다." << std::endl;
+    std::exit(1);
+  }
+
+  return string(cwd);
+}
+
+string SSD_EXE::readOutputFile() {
+  std::ifstream infile(ssdDir + "\\" + SSD_OUTPUT_FILE);
+  if (!infile.is_open()) {
+    return ERROR_MSG;
+  }
+
+  std::string line;
+  if (std::getline(infile, line)) {
+    return line;
+  }
+
+  return "";
+}

--- a/Testshell/ssd_exe.h
+++ b/Testshell/ssd_exe.h
@@ -12,57 +12,9 @@ class SSD_EXE : public SSD_INTERFACE {
 public:
   SSD_EXE() : ssdDir(getCurWorkingDir()) {}
 
-  void read(int lba) override {
-    std::ostringstream cmd;
-    cmd << "\"" << ssdDir << "\\" << SSD_EXE_NAME << "\" R " << lba;
-#ifdef _DEBUG
-    std::cout << cmd.str() << "\n";
-#else
-    int ret = system(cmd.str().c_str());
-    if (ret != 0) {
-      lastResult = ERROR_MSG;
-    } else {
-      lastResult = readOutputFile();
-    }
-#endif
-  }
-
-  void write(int lba, unsigned long value) override {
-    std::ostringstream cmd;
-    cmd << "\"" << ssdDir << "\\" << SSD_EXE_NAME << "\" W " << lba << " 0x"
-        << std::hex << std::uppercase << value;
-#ifdef _DEBUG
-    std::cout << cmd.str() << "\n";
-#else
-    int ret = system(cmd.str().c_str());
-
-    if (ret != 0) {
-      lastResult = ERROR_MSG;
-    } else {
-      string out = readOutputFile();
-      lastResult = out.empty() ? "" : ERROR_MSG;
-    }
-#endif
-  }
-
-    void erase(int lba, int size) override {
-    std::ostringstream cmd;
-      cmd << "\"" << ssdDir << "\\" << SSD_EXE_NAME << "\" E " << lba
-          << " " << size;
-#ifdef _DEBUG
-    std::cout << cmd.str() << "\n";
-#else
-    int ret = system(cmd.str().c_str());
-
-    if (ret != 0) {
-      lastResult = ERROR_MSG;
-    } else {
-      string out = readOutputFile();
-      lastResult = out.empty() ? "" : ERROR_MSG;
-    }
-#endif
-  }
-
+  void read(int lba) override;
+  void write(int lba, unsigned long value) override;
+  void erase(int lba, int size) override ;
   string getResult() override { return lastResult; }
 
 private:
@@ -72,27 +24,6 @@ private:
   const string SSD_OUTPUT_FILE = "ssd_output.txt";
   const string ERROR_MSG = "ERROR";
 
-  string getCurWorkingDir() {
-    char cwd[1024];
-    if (!_getcwd(cwd, sizeof(cwd))) {
-      std::cerr << "[ERROR] 현재 경로를 얻을 수 없습니다." << std::endl;
-      std::exit(1);
-    }
-
-    return string(cwd);
-  }
-
-  string readOutputFile() {
-    std::ifstream infile(ssdDir + "\\" + SSD_OUTPUT_FILE);
-    if (!infile.is_open()) {
-      return ERROR_MSG;
-    }
-
-    std::string line;
-    if (std::getline(infile, line)) {
-      return line;
-    }
-
-    return "";
-  }
+  string getCurWorkingDir();
+  string readOutputFile();
 };

--- a/Testshell/ssd_exe_test.cpp
+++ b/Testshell/ssd_exe_test.cpp
@@ -1,4 +1,4 @@
-#include "ssd_exe.cpp"
+#include "ssd_exe.h"
 #include "gmock/gmock.h"
 using testing::internal::CaptureStdout;
 using testing::internal::GetCapturedStdout;

--- a/Testshell/test_shell.h
+++ b/Testshell/test_shell.h
@@ -8,7 +8,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "ssd_interface.h"
+#include "ssd_exe.h"
 #include "logger.h"
 
 using std::cout;


### PR DESCRIPTION
## 📝 배경
> 어떤 기능이나 문제를 해결했나요?
- master 에서 빌드 오류 개선
- ssd_exe 의 선언부와 구현부가 통일되어 있어서 refactoring 을 위해 분리

## 📝 세부 사항
> 세부 사항을 기록해주세요.
- - ssd_exe 를 ssd_exe.cpp 와 ssd_exe.h 로 분리하여 ssd_exe.h 만 include 하게 변경하였습니다.

## ✅ 체크리스트
다음 항목을 모두 만족하는 지 한번 더 확인 해주세요.
- [x] 코드 스타일 가이드에 맞게 작성함 (LLVM)
- [x] 최신 master를 merge하여 conflict를 해결함
- [x] 유닛 테스트를 모두 통과함
- [x] 배경 및 세부 사항을 적절히 기술함
