### PR TITLE
erase 의 bound 경계값 수정

### DIFF
--- a/SSD/ssd_driver.cpp
+++ b/SSD/ssd_driver.cpp
@@ -23,7 +23,7 @@ public:
     return size >= MIN_ERASE_SIZE && size <= MAX_ERASE_SIZE;
   }
   bool isWithinBounds(int lba, int size) {
-    return (lba + size) < MAX_NAND_MEMORY_MAP_SIZE;
+    return (lba + size) <= MAX_NAND_MEMORY_MAP_SIZE;
   }
 
   bool read(int lba) override {


### PR DESCRIPTION
## 📝 배경
> 어떤 기능이나 문제를 해결했나요?
- erase bound 경계값 수정

## 📝 세부 사항
> 세부 사항을 기록해주세요.
- erase 의 경계값 체크시, lba + size 가 100 까지 포함해야 합니다.

## ✅ 체크리스트
다음 항목을 모두 만족하는 지 한번 더 확인 해주세요.
- [x] 코드 스타일 가이드에 맞게 작성함 (LLVM)
- [x] 최신 master를 merge하여 conflict를 해결함
- [x] 유닛 테스트를 모두 통과함
- [x] 배경 및 세부 사항을 적절히 기술함
