### PR TITLE
[bugfix] longtime fullread fix

### DIFF
--- a/SSD/file_iostream.cpp
+++ b/SSD/file_iostream.cpp
@@ -40,6 +40,8 @@ void IoStream::loadNandFiletoBuf() {
   ifstream ifs(nand_file_name);
 
   if (!ifs) {
+    initSsdNand();
+    clearOutput();
     return;
   }
 


### PR DESCRIPTION
## 📝 배경
> 어떤 기능이나 문제를 해결했나요?
- fullread 오래걸리는 issue로 ssd txt file이 없을 때 발생

## 📝 세부 사항
> 세부 사항을 기록해주세요.
- 최소 load 시도시 파일 생성해주도록 변경

## ✅ 체크리스트
다음 항목을 모두 만족하는 지 한번 더 확인 해주세요.
- [x] 코드 스타일 가이드에 맞게 작성함 (LLVM)
- [x] 최신 master를 merge하여 conflict를 해결함
- [x] 유닛 테스트를 모두 통과함
- [x] 배경 및 세부 사항을 적절히 기술함
