### PR TITLE
Refact/unit test and ssdexe

### DIFF
--- a/Testshell/Testshell.vcxproj
+++ b/Testshell/Testshell.vcxproj
@@ -144,9 +144,9 @@
     <ClCompile Include="fullwrite_command.cpp" />
     <ClCompile Include="help_command.cpp" />
     <ClCompile Include="read_command.cpp" />
-    <ClCompile Include="ssd_exe.cpp" />
-    <ClCompile Include="ssd_exe.h" />
-    <ClCompile Include="ssd_exe_test.cpp" />
+    <ClCompile Include="ssd_adaptor.cpp" />
+    <ClCompile Include="ssd_adaptor.h" />
+    <ClCompile Include="ssd_adaptor_test.cpp" />
     <ClCompile Include="test_script_command.cpp" />
     <ClCompile Include="test_shell.cpp" />
     <ClCompile Include="write_command.cpp" />

--- a/Testshell/Testshell.vcxproj.filters
+++ b/Testshell/Testshell.vcxproj.filters
@@ -72,13 +72,13 @@
     <ClCompile Include="logger_test.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
-    <ClCompile Include="ssd_exe.h">
+    <ClCompile Include="ssd_adaptor.h">
       <Filter>헤더 파일</Filter>
     </ClCompile>
-    <ClCompile Include="ssd_exe_test.cpp">
+    <ClCompile Include="ssd_adaptor_test.cpp">
       <Filter>소스 파일\ssd_interface</Filter>
     </ClCompile>
-    <ClCompile Include="ssd_exe.cpp">
+    <ClCompile Include="ssd_adaptor.cpp">
       <Filter>소스 파일\ssd_interface</Filter>
     </ClCompile>
     <ClCompile Include="flush_command.cpp">

--- a/Testshell/command.h
+++ b/Testshell/command.h
@@ -235,7 +235,7 @@ class CommandHandler {
 public:
   ~CommandHandler() = default;
   CommandHandler() { initialize(); }
-  CommandHandler(SSD_INTERFACE *ssdDriver) : _ssdDriver(ssdDriver) {
+  CommandHandler(SSD_INTERFACE *ssdAdaptor) : _ssdAdaptor(ssdAdaptor) {
     initialize();
   }
 
@@ -247,7 +247,7 @@ public:
 
 private:
   vector<ICommand *> commands;
-  SSD_INTERFACE *_ssdDriver;
+  SSD_INTERFACE *_ssdAdaptor;
 
   void addCommand(ICommand *command);
   void removeCommand(const string &commandName);

--- a/Testshell/command_handler.cpp
+++ b/Testshell/command_handler.cpp
@@ -6,7 +6,7 @@
 bool CommandHandler::executeCommand(const CommandLine &cli) {
   auto command = getCommand(cli.command);
   if (command) {
-    return command->execute(*_ssdDriver, cli);
+    return command->execute(*_ssdAdaptor, cli);
   }
   cout << "INVALID COMMAND" << endl;
   return false;

--- a/Testshell/main.cpp
+++ b/Testshell/main.cpp
@@ -1,7 +1,7 @@
 #include <fstream>
 
 #include "test_shell.h"
-#include "ssd_exe.h"
+#include "ssd_adaptor.h"
 #include "gmock/gmock.h"
 
 // stdout 캡처/해제 함수
@@ -10,7 +10,7 @@ using testing::internal::GetCapturedStdout;
 using namespace testing;
 
 // MockDriver
-class MockSSD : public SSD_INTERFACE {
+class MockSsdAdaptor : public SSD_INTERFACE {
 public:
   MOCK_METHOD(void, read, (int lba), (override));
   MOCK_METHOD(void, write, (int lba, unsigned long value), (override));
@@ -21,7 +21,7 @@ public:
 
 class TestShellFixture : public ::testing::Test {
 public:
-  NiceMock<MockSSD> ssd;
+  NiceMock<MockSsdAdaptor> ssd;
   TestShell ts{&ssd};
 
   string randomValue = convertHexToString(getRandomValue());
@@ -474,7 +474,7 @@ int main(int argc, char *argv[]) {
   ::testing::InitGoogleTest();
   return RUN_ALL_TESTS();
 #else
-  SSD_EXE ssd;
+  SsdExeAdaptor ssd;
   TestShell testShell{&ssd};
 
   if (argc > 1) {

--- a/Testshell/main.cpp
+++ b/Testshell/main.cpp
@@ -35,73 +35,80 @@ public:
   const string TEST_SCRIPT_4_FULLNAME = "4_EraseAndWriteAging";
   const string TEST_SCRIPT_4_SHORTCUT = "4_";
 
+  const string SCRIPT_FAIL = "FAIL!";
+  const string SCRIPT_PASS = "Pass";
+
+  const string INVALID_COMMAND = "INVALID COMMAND\n";
+
   string getCallHelpOutput() {
     CaptureStdout();
     ts.getCommandHandler()->executeCommand(CommandLine{"help", {}});
     return GetCapturedStdout();
   }
+
+  string getCommandOutput(const CommandLine &command) {
+    CaptureStdout();
+    ts.getCommandHandler()->executeCommand(command);
+    return GetCapturedStdout();
+  }
+
+  void checkExpectedStrInOutput(const std::string &output,
+                                const std::string &expectedStr) {
+    EXPECT_TRUE(output.find(expectedStr) != std::string::npos)
+        << "Expected string not found in output: " << expectedStr << endl
+        << "Actual string: " << output << endl;
+  }
+
+  void checkExpectedStrsInOutput(const std::string &output,
+                                 const vector<std::string> &expectedStrs) {
+    for (auto &expectedStr : expectedStrs)
+      EXPECT_TRUE(output.find(expectedStr) != std::string::npos)
+          << "Expected string not found in output: " << expectedStr << endl
+          << "Actual string: " << output << endl;
+  }
 };
 
 TEST_F(TestShellFixture, DisplaysCorrectHeader) {
-  std::string output = getCallHelpOutput();
-
-  EXPECT_TRUE(
-      output.find("SSD Test Shell - Simple and Powerful SSD Testing Tool") !=
-      std::string::npos);
+  checkExpectedStrInOutput(
+      getCallHelpOutput(),
+      "SSD Test Shell - Simple and Powerful SSD Testing Tool");
 }
 
 TEST_F(TestShellFixture, DisplaysTeamMembers) {
-  std::string output = getCallHelpOutput();
-
-  EXPECT_TRUE(output.find("Team Members:") != std::string::npos);
-  EXPECT_TRUE(output.find("Taehyun Kyong") != std::string::npos);
-  EXPECT_TRUE(output.find("Sunghwan Kim") != std::string::npos);
-  EXPECT_TRUE(output.find("Hyeonseok Sim") != std::string::npos);
-  EXPECT_TRUE(output.find("Yerim Yun") != std::string::npos);
-  EXPECT_TRUE(output.find("Hoenhwi Jeong") != std::string::npos);
-  EXPECT_TRUE(output.find("Jeseong Kim") != std::string::npos);
+  vector<string> expectedMembers = {"Taehyun Kyong", "Sunghwan Kim",
+                                    "Hyeonseok Sim", "Yerim Yun",
+                                    "Hoenhwi Jeong", "Jeseong Kim"};
+  checkExpectedStrsInOutput(getCallHelpOutput(), expectedMembers);
 }
 
 TEST_F(TestShellFixture, DisplaysCommandsSection) {
-  std::string output = getCallHelpOutput();
-
-  EXPECT_TRUE(output.find("Commands:") != std::string::npos);
-
-  EXPECT_TRUE(output.find("read") != std::string::npos);
-  EXPECT_TRUE(output.find("read 10") != std::string::npos);
-
-  EXPECT_TRUE(output.find("write") != std::string::npos);
-  EXPECT_TRUE(output.find("write 5 0xFF") != std::string::npos);
-
-  EXPECT_TRUE(output.find("fullread") != std::string::npos);
-  EXPECT_TRUE(output.find("Read the entire SSD") != std::string::npos);
-
-  EXPECT_TRUE(output.find("fullwrite") != std::string::npos);
-  EXPECT_TRUE(output.find("fullwrite 0x00") != std::string::npos);
-
-  EXPECT_TRUE(output.find("help") != std::string::npos);
-  EXPECT_TRUE(output.find("Show this help message") != std::string::npos);
-
-  EXPECT_TRUE(output.find("exit") != std::string::npos);
-  EXPECT_TRUE(output.find("Exit the shell") != std::string::npos);
-
-  EXPECT_TRUE(output.find("erase") != std::string::npos);
-  EXPECT_TRUE(output.find("erase 0 10") != std::string::npos);
-
-  EXPECT_TRUE(output.find("erase_range") != std::string::npos);
-  EXPECT_TRUE(output.find("erase_range 0 99") != std::string::npos);
-
-  EXPECT_TRUE(output.find("flush") != std::string::npos);
-  EXPECT_TRUE(output.find("Flush all buffered commands to SSD") != std::string::npos);
+  vector<string> expectedCommands = {"Commands:",
+                                     "read",
+                                     "read 10",
+                                     "write",
+                                     "write 5 0xFF",
+                                     "fullread",
+                                     "Read the entire SSD",
+                                     "fullwrite",
+                                     "fullwrite 0x00",
+                                     "help",
+                                     "Show this help message",
+                                     "exit",
+                                     "Exit the shell",
+                                     "erase",
+                                     "erase 0 10",
+                                     "erase_range",
+                                     "erase_range 0 99",
+                                     "flush",
+                                     "Flush all buffered commands to SSD"};
+  checkExpectedStrsInOutput(getCallHelpOutput(), expectedCommands);
 }
 
 TEST_F(TestShellFixture, DisplayTestScriptsSection) {
-  std::string output = getCallHelpOutput();
-
-  EXPECT_TRUE(output.find("1_FullWriteAndReadCompare") != std::string::npos);
-  EXPECT_TRUE(output.find("2_PartialLBAWrite") != std::string::npos);
-  EXPECT_TRUE(output.find("3_WriteReadAging") != std::string::npos);
-  EXPECT_TRUE(output.find("4_EraseAndWriteAging") != std::string::npos);
+  vector<string> expectedScripts = {"1_FullWriteAndReadCompare",
+                                    "2_PartialLBAWrite", "3_WriteReadAging",
+                                    "4_EraseAndWriteAging"};
+  checkExpectedStrsInOutput(getCallHelpOutput(), expectedScripts);
 }
 
 TEST_F(TestShellFixture, ReadNormalCase) {
@@ -155,13 +162,15 @@ TEST_F(TestShellFixture, WriteInvalidCase) {
 
   ts.getCommandHandler()->executeCommand(InvalidFormatCmd);
 
-  CommandLine OverflowLbaCmd{"write", vector<string>{"2147483648", "0xAAAABBBB"}};
+  CommandLine OverflowLbaCmd{"write",
+                             vector<string>{"2147483648", "0xAAAABBBB"}};
   EXPECT_CALL(ssd, write(_, _)).Times(0);
   EXPECT_CALL(ssd, getResult()).Times(0);
 
   ts.getCommandHandler()->executeCommand(OverflowLbaCmd);
 
-  CommandLine OverflowValueCmd{"write", vector<string>{"0", "0xAAAABBBBAAAABBBB"}};
+  CommandLine OverflowValueCmd{"write",
+                               vector<string>{"0", "0xAAAABBBBAAAABBBB"}};
   EXPECT_CALL(ssd, write(_, _)).Times(0);
   EXPECT_CALL(ssd, getResult()).Times(0);
 
@@ -189,11 +198,7 @@ TEST_F(TestShellFixture, EraseInvalidCase) {
     EXPECT_CALL(ssd, erase(_, _)).Times(0);
     EXPECT_CALL(ssd, getResult()).Times(0);
 
-    CaptureStdout();
-    ts.getCommandHandler()->executeCommand(command);
-    std::string output = GetCapturedStdout();
-
-    EXPECT_EQ("INVALID COMMAND\n", output);
+    checkExpectedStrInOutput(getCommandOutput(command), INVALID_COMMAND);
   }
 }
 
@@ -218,11 +223,7 @@ TEST_F(TestShellFixture, EraseRangeInvalidCase) {
     EXPECT_CALL(ssd, erase(_, _)).Times(0);
     EXPECT_CALL(ssd, getResult()).Times(0);
 
-    CaptureStdout();
-    ts.getCommandHandler()->executeCommand(command);
-    std::string output = GetCapturedStdout();
-
-    EXPECT_EQ("INVALID COMMAND\n", output);
+    checkExpectedStrInOutput(getCommandOutput(command), INVALID_COMMAND);
   }
 }
 
@@ -232,11 +233,7 @@ TEST_F(TestShellFixture, FlushNormalCase) {
   EXPECT_CALL(ssd, flush()).Times(1);
   EXPECT_CALL(ssd, getResult()).Times(1).WillOnce(Return(""));
 
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(command);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_EQ("[Flush] Done\n", output);
+  checkExpectedStrInOutput(getCommandOutput(command), "[Flush] Done\n");
 }
 
 TEST_F(TestShellFixture, FlushErrorCase) {
@@ -245,37 +242,18 @@ TEST_F(TestShellFixture, FlushErrorCase) {
   EXPECT_CALL(ssd, flush()).Times(1);
   EXPECT_CALL(ssd, getResult()).Times(1).WillOnce(Return("ERROR"));
 
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(command);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_EQ("[Flush] ERROR\n", output);
+  checkExpectedStrInOutput(getCommandOutput(command), "[Flush] ERROR\n");
 }
 
 TEST_F(TestShellFixture, FlushInvalidUsage) {
-  CommandLine command{"flush", vector<string>{"extra_arg"}};
+  vector<CommandLine> commands = {{"flush", vector<string>{"extra_arg"}},
+                                  {"flush", vector<string>{"arg1", "arg2"}}};
+  for (auto command : commands) {
+    EXPECT_CALL(ssd, flush()).Times(0);
+    EXPECT_CALL(ssd, getResult()).Times(0);
 
-  EXPECT_CALL(ssd, flush()).Times(0);
-  EXPECT_CALL(ssd, getResult()).Times(0);
-
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(command);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_EQ("INVALID COMMAND\n", output);
-}
-
-TEST_F(TestShellFixture, FlushMultipleArgsInvalidUsage) {
-  CommandLine command{"flush", vector<string>{"arg1", "arg2"}};
-
-  EXPECT_CALL(ssd, flush()).Times(0);
-  EXPECT_CALL(ssd, getResult()).Times(0);
-
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(command);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_EQ("INVALID COMMAND\n", output);
+    checkExpectedStrInOutput(getCommandOutput(command), INVALID_COMMAND);
+  }
 }
 
 TEST_F(TestShellFixture, FullReadSuccessCase) {
@@ -284,11 +262,7 @@ TEST_F(TestShellFixture, FullReadSuccessCase) {
   EXPECT_CALL(ssd, read(_)).Times(100);
   EXPECT_CALL(ssd, getResult()).Times(100).WillRepeatedly(Return("0xAAAABBBB"));
 
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(command);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_TRUE(output.find("[Full Read] Done != std::string::npos"));
+  checkExpectedStrInOutput(getCommandOutput(command), "[Full Read] Done\n");
 }
 
 TEST_F(TestShellFixture, FullReadFailCase) {
@@ -306,13 +280,9 @@ TEST_F(TestShellFixture, FullReadFailCase) {
       .WillOnce(Return("0xEEEEFFFF"))
       .WillOnce(Return("ERROR"));
 
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(command);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_TRUE(output.find("LBA 00 : 0xAAAABBBB") != std::string::npos);
-  EXPECT_TRUE(output.find("LBA 01 : 0xCCCCDDDD") != std::string::npos);
-  EXPECT_TRUE(output.find("LBA 02 : 0xEEEEFFFF") != std::string::npos);
+  vector<string> expectedOutput = {"LBA 00 : 0xAAAABBBB", "LBA 01 : 0xCCCCDDDD",
+                                   "LBA 02 : 0xEEEEFFFF"};
+  checkExpectedStrsInOutput(getCommandOutput(command), expectedOutput);
 }
 
 TEST_F(TestShellFixture, FullReadInvalidUsage) {
@@ -321,10 +291,7 @@ TEST_F(TestShellFixture, FullReadInvalidUsage) {
   EXPECT_CALL(ssd, read(_)).Times(0);
   EXPECT_CALL(ssd, getResult()).Times(0);
 
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(command);
-  std::string output = GetCapturedStdout();
-  EXPECT_EQ("INVALID COMMAND\n", output);
+  checkExpectedStrInOutput(getCommandOutput(command), INVALID_COMMAND);
 }
 
 // fullwrite 테스트들
@@ -335,11 +302,7 @@ TEST_F(TestShellFixture, FullWriteSuccessCase) {
   EXPECT_CALL(ssd, write(_, _)).Times(100);
   EXPECT_CALL(ssd, getResult()).Times(100).WillRepeatedly(Return("0xABCDABCD"));
 
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(command);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_TRUE(output.find("[Full Write] Done") != std::string::npos);
+  checkExpectedStrInOutput(getCommandOutput(command), "[Full Write] Done");
 }
 
 TEST_F(TestShellFixture, FullWriteFailCase) {
@@ -358,50 +321,20 @@ TEST_F(TestShellFixture, FullWriteFailCase) {
       .WillOnce(Return(""))
       .WillOnce(Return("ERROR"));
 
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(command);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_TRUE(output.find("[Full Write] Failed") != std::string::npos);
+  checkExpectedStrInOutput(getCommandOutput(command), "[Full Write] Failed");
 }
 
 TEST_F(TestShellFixture, FullWriteInvalidArgumentCount) {
-  CommandLine command{"fullwrite", vector<string>{"0xABCDABCD", "extraArgs"}};
+  vector<CommandLine> commands = {
+      {"fullwrite", vector<string>{"0xABCDABCD", "extraArgs"}},
+      {"fullwrite", vector<string>{}},
+      {"fullwrite", vector<string>{"invalid_number"}}};
+  for (auto command : commands) {
+    EXPECT_CALL(ssd, write(_, _)).Times(0);
+    EXPECT_CALL(ssd, getResult()).Times(0);
 
-  EXPECT_CALL(ssd, write(_, _)).Times(0);
-  EXPECT_CALL(ssd, getResult()).Times(0);
-
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(command);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_EQ("INVALID COMMAND\n", output);
-}
-
-TEST_F(TestShellFixture, FullWriteNoArguments) {
-  CommandLine command{"fullwrite", vector<string>{}};
-
-  EXPECT_CALL(ssd, write(_, _)).Times(0);
-  EXPECT_CALL(ssd, getResult()).Times(0);
-
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(command);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_EQ("INVALID COMMAND\n", output);
-}
-
-TEST_F(TestShellFixture, FullWriteInvalidValue) {
-  CommandLine command{"fullwrite", vector<string>{"invalid_number"}};
-
-  EXPECT_CALL(ssd, write(_, _)).Times(0);
-  EXPECT_CALL(ssd, getResult()).Times(0);
-
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(command);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_EQ("INVALID COMMAND\n", output);
+    checkExpectedStrInOutput(getCommandOutput(command), INVALID_COMMAND);
+  }
 }
 
 TEST_F(TestShellFixture, ExitNormally) {
@@ -416,108 +349,33 @@ TEST_F(TestShellFixture, ExitInvalidArgs) {
   std::string output = GetCapturedStdout();
 }
 
-TEST_F(TestShellFixture, TestScript1FAIL) {
-  CommandLine cmd{TEST_SCRIPT_1_FULLNAME};
+TEST_F(TestShellFixture, TestScript1_2FAIL) {
+  vector<CommandLine> commands = {
+      {TEST_SCRIPT_1_FULLNAME, {}},
+      {TEST_SCRIPT_1_SHORTCUT, {}},
+      {TEST_SCRIPT_2_FULLNAME, {}},
+      {TEST_SCRIPT_2_SHORTCUT, {}},
+  };
+  for (auto command : commands) {
+    EXPECT_CALL(ssd, write(_, 0xAAAABBBB)).Times(AtLeast(1));
+    EXPECT_CALL(ssd, getResult()).WillRepeatedly(Return("0xFFFFFFFF"));
 
-  EXPECT_CALL(ssd, write(_, 0xAAAABBBB)).Times(AtLeast(1));
-  EXPECT_CALL(ssd, getResult()).WillRepeatedly(Return("0xFFFFFFFF"));
-
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(cmd);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_TRUE(output.find("FAIL!\n") != std::string::npos);
+    checkExpectedStrInOutput(getCommandOutput(command), SCRIPT_FAIL);
+  }
 }
 
-TEST_F(TestShellFixture, TestScript1ShortcutFAIL) {
-  CommandLine cmd{TEST_SCRIPT_1_SHORTCUT};
+TEST_F(TestShellFixture, TestScript1_2SUCCESS) {
+  vector<CommandLine> commands = {
+      {TEST_SCRIPT_1_FULLNAME, {}},
+      {TEST_SCRIPT_1_SHORTCUT, {}},
+      {TEST_SCRIPT_2_FULLNAME, {}},
+  };
+  for (auto command : commands) {
+    EXPECT_CALL(ssd, write(_, 0xAAAABBBB)).Times(AtLeast(1));
+    EXPECT_CALL(ssd, getResult()).WillRepeatedly(Return("0xAAAABBBB"));
 
-  EXPECT_CALL(ssd, write(_, 0xAAAABBBB)).Times(AtLeast(1));
-  EXPECT_CALL(ssd, getResult()).WillRepeatedly(Return("0xFFFFFFFF"));
-
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(cmd);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_TRUE(output.find("FAIL!\n") != std::string::npos);
-}
-
-TEST_F(TestShellFixture, TestScript1SUCCESS) {
-  CommandLine cmd{TEST_SCRIPT_1_FULLNAME};
-
-  EXPECT_CALL(ssd, write(_, 0xAAAABBBB)).Times(100);
-  EXPECT_CALL(ssd, getResult()).WillRepeatedly(Return("0xAAAABBBB"));
-
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(cmd);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_EQ("Pass\n", output);
-}
-
-TEST_F(TestShellFixture, TestScript1ShortcutSUCCESS) {
-  CommandLine cmd{TEST_SCRIPT_1_SHORTCUT};
-
-  EXPECT_CALL(ssd, write(_, 0xAAAABBBB)).Times(100);
-  EXPECT_CALL(ssd, getResult()).WillRepeatedly(Return("0xAAAABBBB"));
-
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(cmd);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_EQ("Pass\n", output);
-}
-
-TEST_F(TestShellFixture, TestScript2FAIL) {
-  CommandLine cmd{TEST_SCRIPT_2_FULLNAME};
-
-  EXPECT_CALL(ssd, write(_, 0xAAAABBBB)).Times(AtLeast(1));
-  EXPECT_CALL(ssd, getResult()).WillRepeatedly(Return("0xFFFFFFFF"));
-
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(cmd);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_TRUE(output.find("FAIL!\n") != std::string::npos);
-}
-
-TEST_F(TestShellFixture, TestScript2ShortcutFAIL) {
-  CommandLine cmd{TEST_SCRIPT_2_SHORTCUT};
-
-  EXPECT_CALL(ssd, write(_, 0xAAAABBBB)).Times(AtLeast(1));
-  EXPECT_CALL(ssd, getResult()).WillRepeatedly(Return("0xFFFFFFFF"));
-
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(cmd);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_TRUE(output.find("FAIL!\n") != std::string::npos);
-}
-
-TEST_F(TestShellFixture, TestScript2SUCCESS) {
-  CommandLine cmd{TEST_SCRIPT_2_FULLNAME};
-
-  EXPECT_CALL(ssd, write(_, 0xAAAABBBB)).Times(150);
-  EXPECT_CALL(ssd, getResult()).WillRepeatedly(Return("0xAAAABBBB"));
-
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(cmd);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_EQ("Pass\n", output);
-}
-
-TEST_F(TestShellFixture, TestScript2ShortcutSUCCESS) {
-  CommandLine cmd{TEST_SCRIPT_2_SHORTCUT};
-
-  EXPECT_CALL(ssd, write(_, 0xAAAABBBB)).Times(150);
-  EXPECT_CALL(ssd, getResult()).WillRepeatedly(Return("0xAAAABBBB"));
-
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(cmd);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_EQ("Pass\n", output);
+    checkExpectedStrInOutput(getCommandOutput(command), SCRIPT_PASS);
+  }
 }
 
 TEST_F(TestShellFixture, TestScript3FAIL) {
@@ -530,7 +388,7 @@ TEST_F(TestShellFixture, TestScript3FAIL) {
   ts.getCommandHandler()->executeCommand(cmd);
   std::string output = GetCapturedStdout();
 
-  EXPECT_TRUE(output.find("FAIL!\n") != std::string::npos);
+  EXPECT_TRUE(output.find(SCRIPT_FAIL) != std::string::npos);
 }
 
 TEST_F(TestShellFixture, TestScript3ShortcutFAIL) {
@@ -539,11 +397,7 @@ TEST_F(TestShellFixture, TestScript3ShortcutFAIL) {
   EXPECT_CALL(ssd, write(_, _)).Times(AtLeast(1));
   EXPECT_CALL(ssd, read(_)).Times(AtLeast(1));
 
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(cmd);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_TRUE(output.find("FAIL!\n") != std::string::npos);
+  checkExpectedStrInOutput(getCommandOutput(cmd), SCRIPT_FAIL);
 }
 
 TEST_F(TestShellFixture, TestScript3SUCCESS) {
@@ -553,11 +407,7 @@ TEST_F(TestShellFixture, TestScript3SUCCESS) {
   EXPECT_CALL(ssd, read(_)).Times(400);
   EXPECT_CALL(ssd, getResult()).WillRepeatedly(Return(randomValue));
 
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(cmd);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_EQ("Pass\n", output);
+  checkExpectedStrInOutput(getCommandOutput(cmd), SCRIPT_PASS);
 }
 
 TEST_F(TestShellFixture, TestScript3ShortcutSUCCESS) {
@@ -567,16 +417,12 @@ TEST_F(TestShellFixture, TestScript3ShortcutSUCCESS) {
   EXPECT_CALL(ssd, read(_)).Times(400);
   EXPECT_CALL(ssd, getResult()).WillRepeatedly(Return(randomValue));
 
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(cmd);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_EQ("Pass\n", output);
+  checkExpectedStrInOutput(getCommandOutput(cmd), SCRIPT_PASS);
 }
 
 TEST_F(TestShellFixture, TestScript4FAIL) {
   vector<CommandLine> commands = {{TEST_SCRIPT_4_FULLNAME, {}},
-                              {TEST_SCRIPT_4_SHORTCUT, {}}};
+                                  {TEST_SCRIPT_4_SHORTCUT, {}}};
 
   for (auto cmd : commands) {
     EXPECT_CALL(ssd, erase(_, _)).Times(AtLeast(1));
@@ -586,39 +432,27 @@ TEST_F(TestShellFixture, TestScript4FAIL) {
         .WillOnce(Return(""))
         .WillOnce(Return("ERROR"));
 
-    CaptureStdout();
-    ts.getCommandHandler()->executeCommand(cmd);
-    std::string output = GetCapturedStdout();
-
-    EXPECT_TRUE(output.find("FAIL!\n") != std::string::npos);
+    checkExpectedStrInOutput(getCommandOutput(cmd), SCRIPT_FAIL);
   }
 }
 
 TEST_F(TestShellFixture, TestScript4SUCCESS) {
   vector<CommandLine> commands = {{TEST_SCRIPT_4_FULLNAME, {}},
-                              {TEST_SCRIPT_4_SHORTCUT, {}}};
+                                  {TEST_SCRIPT_4_SHORTCUT, {}}};
 
   for (auto cmd : commands) {
     EXPECT_CALL(ssd, erase(_, _)).Times(49 * 30 + 1);
     EXPECT_CALL(ssd, write(_, _)).Times(98 * 30);
     EXPECT_CALL(ssd, getResult()).WillRepeatedly(Return(""));
 
-    CaptureStdout();
-    ts.getCommandHandler()->executeCommand(cmd);
-    std::string output = GetCapturedStdout();
-
-    EXPECT_EQ("Pass\n", output);
+    checkExpectedStrInOutput(getCommandOutput(cmd), SCRIPT_PASS);
   }
 }
 
 TEST_F(TestShellFixture, InvalidCommand) {
   CommandLine cmd{"INVALID"};
 
-  CaptureStdout();
-  ts.getCommandHandler()->executeCommand(cmd);
-  std::string output = GetCapturedStdout();
-
-  EXPECT_EQ("INVALID COMMAND\n", output);
+  checkExpectedStrInOutput(getCommandOutput(cmd), INVALID_COMMAND);
 }
 
 std::vector<std::string> getScripts(const std::string &filename) {

--- a/Testshell/main.cpp
+++ b/Testshell/main.cpp
@@ -55,16 +55,19 @@ public:
   void checkExpectedStrInOutput(const std::string &output,
                                 const std::string &expectedStr) {
     EXPECT_TRUE(output.find(expectedStr) != std::string::npos)
-        << "Expected string not found in output: " << expectedStr << endl
+        << "Expected string not found in output"
+        << "Expect string: " << expectedStr << endl
         << "Actual string: " << output << endl;
   }
 
   void checkExpectedStrsInOutput(const std::string &output,
                                  const vector<std::string> &expectedStrs) {
-    for (auto &expectedStr : expectedStrs)
+    for (auto &expectedStr : expectedStrs) {
       EXPECT_TRUE(output.find(expectedStr) != std::string::npos)
-          << "Expected string not found in output: " << expectedStr << endl
+          << "Expected string not found in output"
+          << "Expect string: " << expectedStr << endl
           << "Actual string: " << output << endl;
+    }
   }
 };
 

--- a/Testshell/ssd_adaptor.cpp
+++ b/Testshell/ssd_adaptor.cpp
@@ -2,8 +2,8 @@
 
 using std::string;
 
-void SsdExeAdaptor::read(int lba) {
-  logger.print("SSD_EXE.read()", "Reading LBA: " + std::to_string(lba));
+void SsdAdaptor::read(int lba) {
+  logger.print("SsdAdaptor.read()", "Reading LBA: " + std::to_string(lba));
   std::ostringstream cmd;
   cmd << "\"" << ssdDir << "\\" << SSD_EXE_NAME << "\" R " << lba;
 #ifdef _DEBUG
@@ -18,8 +18,8 @@ void SsdExeAdaptor::read(int lba) {
 #endif
 }
 
-void SsdExeAdaptor::write(int lba, unsigned long value) {
-  logger.print("SsdExeAdaptor.write()", "Writing LBA: " + std::to_string(lba) +
+void SsdAdaptor::write(int lba, unsigned long value) {
+  logger.print("SsdAdaptor.write()", "Writing LBA: " + std::to_string(lba) +
                    " with value: " + std::to_string(value));
   std::ostringstream cmd;
   cmd << "\"" << ssdDir << "\\" << SSD_EXE_NAME << "\" W " << lba << " 0x"
@@ -38,8 +38,8 @@ void SsdExeAdaptor::write(int lba, unsigned long value) {
 #endif
 }
 
-void SsdExeAdaptor::erase(int lba, int size) {
-  logger.print("SsdExeAdaptor.erase()", "Erasing LBA: " + std::to_string(lba) +
+void SsdAdaptor::erase(int lba, int size) {
+  logger.print("SsdAdaptor.erase()", "Erasing LBA: " + std::to_string(lba) +
                                       " with size: " + std::to_string(size));
   std::ostringstream cmd;
   cmd << "\"" << ssdDir << "\\" << SSD_EXE_NAME << "\" E " << lba << " "
@@ -59,8 +59,8 @@ void SsdExeAdaptor::erase(int lba, int size) {
 }
 
 
-void SsdExeAdaptor::flush() {
-  logger.print("SsdExeAdaptor.flush()", "Flushing SSD commands");
+void SsdAdaptor::flush() {
+  logger.print("SsdAdaptor.flush()", "Flushing SSD commands");
   std::ostringstream cmd;
   cmd << "\"" << ssdDir << "\\" << SSD_EXE_NAME << "\" F";
 #ifdef _DEBUG
@@ -72,7 +72,7 @@ void SsdExeAdaptor::flush() {
 #endif
 }
 
-string SsdExeAdaptor::getCurWorkingDir() {
+string SsdAdaptor::getCurWorkingDir() {
   char cwd[1024];
   if (!_getcwd(cwd, sizeof(cwd))) {
     std::cerr << "[ERROR] 현재 경로를 얻을 수 없습니다." << std::endl;
@@ -82,7 +82,7 @@ string SsdExeAdaptor::getCurWorkingDir() {
   return string(cwd);
 }
 
-string SsdExeAdaptor::readOutputFile() {
+string SsdAdaptor::readOutputFile() {
   std::ifstream infile(ssdDir + "\\" + SSD_OUTPUT_FILE);
   if (!infile.is_open()) {
     return ERROR_MSG;

--- a/Testshell/ssd_adaptor.cpp
+++ b/Testshell/ssd_adaptor.cpp
@@ -1,8 +1,8 @@
-#include "ssd_exe.h"
+#include "ssd_adaptor.h"
 
 using std::string;
 
-void SSD_EXE::read(int lba) {
+void SsdExeAdaptor::read(int lba) {
   logger.print("SSD_EXE.read()", "Reading LBA: " + std::to_string(lba));
   std::ostringstream cmd;
   cmd << "\"" << ssdDir << "\\" << SSD_EXE_NAME << "\" R " << lba;
@@ -18,8 +18,8 @@ void SSD_EXE::read(int lba) {
 #endif
 }
 
-void SSD_EXE::write(int lba, unsigned long value) {
-  logger.print("SSD_EXE.write()", "Writing LBA: " + std::to_string(lba) +
+void SsdExeAdaptor::write(int lba, unsigned long value) {
+  logger.print("SsdExeAdaptor.write()", "Writing LBA: " + std::to_string(lba) +
                    " with value: " + std::to_string(value));
   std::ostringstream cmd;
   cmd << "\"" << ssdDir << "\\" << SSD_EXE_NAME << "\" W " << lba << " 0x"
@@ -38,8 +38,8 @@ void SSD_EXE::write(int lba, unsigned long value) {
 #endif
 }
 
-void SSD_EXE::erase(int lba, int size) {
-  logger.print("SSD_EXE.erase()", "Erasing LBA: " + std::to_string(lba) +
+void SsdExeAdaptor::erase(int lba, int size) {
+  logger.print("SsdExeAdaptor.erase()", "Erasing LBA: " + std::to_string(lba) +
                                       " with size: " + std::to_string(size));
   std::ostringstream cmd;
   cmd << "\"" << ssdDir << "\\" << SSD_EXE_NAME << "\" E " << lba << " "
@@ -59,8 +59,8 @@ void SSD_EXE::erase(int lba, int size) {
 }
 
 
-void SSD_EXE::flush() {
-  logger.print("SSD_EXE.flush()", "Flushing SSD commands");
+void SsdExeAdaptor::flush() {
+  logger.print("SsdExeAdaptor.flush()", "Flushing SSD commands");
   std::ostringstream cmd;
   cmd << "\"" << ssdDir << "\\" << SSD_EXE_NAME << "\" F";
 #ifdef _DEBUG
@@ -72,7 +72,7 @@ void SSD_EXE::flush() {
 #endif
 }
 
-string SSD_EXE::getCurWorkingDir() {
+string SsdExeAdaptor::getCurWorkingDir() {
   char cwd[1024];
   if (!_getcwd(cwd, sizeof(cwd))) {
     std::cerr << "[ERROR] 현재 경로를 얻을 수 없습니다." << std::endl;
@@ -82,7 +82,7 @@ string SSD_EXE::getCurWorkingDir() {
   return string(cwd);
 }
 
-string SSD_EXE::readOutputFile() {
+string SsdExeAdaptor::readOutputFile() {
   std::ifstream infile(ssdDir + "\\" + SSD_OUTPUT_FILE);
   if (!infile.is_open()) {
     return ERROR_MSG;

--- a/Testshell/ssd_adaptor.h
+++ b/Testshell/ssd_adaptor.h
@@ -9,9 +9,9 @@
 
 using std::string;
 
-class SsdExeAdaptor : public SSD_INTERFACE {
+class SsdAdaptor : public SSD_INTERFACE {
 public:
-  SsdExeAdaptor() : ssdDir(getCurWorkingDir()) {}
+  SsdAdaptor() : ssdDir(getCurWorkingDir()) {}
 
   void read(int lba) override;
   void write(int lba, unsigned long value) override;

--- a/Testshell/ssd_adaptor.h
+++ b/Testshell/ssd_adaptor.h
@@ -9,9 +9,9 @@
 
 using std::string;
 
-class SSD_EXE : public SSD_INTERFACE {
+class SsdExeAdaptor : public SSD_INTERFACE {
 public:
-  SSD_EXE() : ssdDir(getCurWorkingDir()) {}
+  SsdExeAdaptor() : ssdDir(getCurWorkingDir()) {}
 
   void read(int lba) override;
   void write(int lba, unsigned long value) override;

--- a/Testshell/ssd_adaptor_test.cpp
+++ b/Testshell/ssd_adaptor_test.cpp
@@ -3,12 +3,12 @@
 using testing::internal::CaptureStdout;
 using testing::internal::GetCapturedStdout;
 
-class SsdExeAdaptorFixture : public ::testing::Test {
+class SsdAdaptorFixture : public ::testing::Test {
 public:
-  SsdExeAdaptor ssd;
+  SsdAdaptor ssd;
 };
 
-TEST_F(SsdExeAdaptorFixture, readNormal) {
+TEST_F(SsdAdaptorFixture, readNormal) {
   CaptureStdout();
   ssd.read(0);
   std::string output = GetCapturedStdout();
@@ -16,7 +16,7 @@ TEST_F(SsdExeAdaptorFixture, readNormal) {
 	  << "Actual stream : " << output;
 }
 
-TEST_F(SsdExeAdaptorFixture, writeNormal) {
+TEST_F(SsdAdaptorFixture, writeNormal) {
   CaptureStdout();
   ssd.write(0, 0xAAAABBBB);
   std::string output = GetCapturedStdout();

--- a/Testshell/ssd_adaptor_test.cpp
+++ b/Testshell/ssd_adaptor_test.cpp
@@ -1,14 +1,14 @@
-#include "ssd_exe.h"
+#include "ssd_adaptor.h"
 #include "gmock/gmock.h"
 using testing::internal::CaptureStdout;
 using testing::internal::GetCapturedStdout;
 
-class SSDEXEFixture : public ::testing::Test {
+class SsdExeAdaptorFixture : public ::testing::Test {
 public:
-  SSD_EXE ssd;
+  SsdExeAdaptor ssd;
 };
 
-TEST_F(SSDEXEFixture, readNormal) {
+TEST_F(SsdExeAdaptorFixture, readNormal) {
   CaptureStdout();
   ssd.read(0);
   std::string output = GetCapturedStdout();
@@ -16,7 +16,7 @@ TEST_F(SSDEXEFixture, readNormal) {
 	  << "Actual stream : " << output;
 }
 
-TEST_F(SSDEXEFixture, writeNormal) {
+TEST_F(SsdExeAdaptorFixture, writeNormal) {
   CaptureStdout();
   ssd.write(0, 0xAAAABBBB);
   std::string output = GetCapturedStdout();


### PR DESCRIPTION
## 📝 배경
> 어떤 기능이나 문제를 해결했나요?
- Unit Test 의 중복 코드 제거 및 클래스 명 변경

## 📝 세부 사항
> 세부 사항을 기록해주세요.
- Unit Test 의 output capture 부분을 함수화하여 중복 코드를 제거했습니다.
- SSD_EXE 로 썼던 class 명을 Adaptor 디자인 패턴을 사용한 클래스명으로 변경하였습니다.

## ✅ 체크리스트
다음 항목을 모두 만족하는 지 한번 더 확인 해주세요.
- [x] 코드 스타일 가이드에 맞게 작성함 (LLVM)
- [x] 최신 master를 merge하여 conflict를 해결함
- [x] 유닛 테스트를 모두 통과함
- [x] 배경 및 세부 사항을 적절히 기술함
