### PR TITLE
[refactoring] Separate logger and test shell

### DIFF
--- a/Testshell/command.h
+++ b/Testshell/command.h
@@ -6,6 +6,7 @@
 #include <random>
 #include <iomanip>
 
+#include "logger.h"
 #include "ssd_interface.h"
 
 using std::cout;
@@ -45,6 +46,7 @@ protected:
   const int MAX_LBA_COUNT = 100;
   const int HEX_BASE = 16;
   string commandName;
+  Logger &logger = Logger::getInstance();
 };
 
 class ExitCommand : public ICommand {
@@ -249,4 +251,5 @@ private:
 
   void addCommand(ICommand *command);
   void removeCommand(const string &commandName);
+  Logger &logger = Logger::getInstance();
 };

--- a/Testshell/command_handler.cpp
+++ b/Testshell/command_handler.cpp
@@ -1,6 +1,7 @@
 #include <sstream>
 
 #include "command.h"
+#include "logger.h"
 
 bool CommandHandler::executeCommand(const CommandLine &cli) {
   auto command = getCommand(cli.command);
@@ -45,6 +46,7 @@ CommandLine CommandHandler::parseCommand(const string &input) {
   string cmd;
   vector<string> args;
   if (iss >> cmd) {
+    logger.print("CommandHandler.parseCommand()", "Parsed command: " + cmd);
     string arg;
     while (iss >> arg) {
       args.push_back(arg);
@@ -54,7 +56,6 @@ CommandLine CommandHandler::parseCommand(const string &input) {
 }
 
 void CommandHandler::initialize() {
-  // Initialize the command handler with default commands
   addCommand(new ExitCommand());
   addCommand(new FullReadCommand());
   addCommand(new FullWriteCommand());

--- a/Testshell/erase_command.cpp
+++ b/Testshell/erase_command.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 
 bool EraseCommand::execute(SSD_INTERFACE &ssd, const CommandLine &cli) {
+  logger.print("EraseCommand.execute()", "Executing erase command");
   if (!isValidEraseUsage(cli)) {
     std::cout << "INVALID COMMAND\n";
     return false;

--- a/Testshell/erase_range_command.cpp
+++ b/Testshell/erase_range_command.cpp
@@ -2,13 +2,13 @@
 #include <algorithm>
 
 bool EraseRangeCommand::execute(SSD_INTERFACE &ssd, const CommandLine &cli) {
+  logger.print("EraseRangeCommand.execute()", "Executing erase range command");
   if (!isValidEraseRangeUsage(cli)) {
     std::cout << "INVALID COMMAND\n";
     return false;
   }
   int st_lba = std::stoi(cli.args[0]);
   int en_lba = std::stoi(cli.args[1]);
-
 
   int remain_size = en_lba - st_lba + 1;
   int unit_size = std::min(MAX_SSD_ERASE_SIZE, remain_size);

--- a/Testshell/exit_command.cpp
+++ b/Testshell/exit_command.cpp
@@ -1,6 +1,7 @@
 #include "command.h"
 
 bool ExitCommand::execute(SSD_INTERFACE &ssd, const CommandLine &cli) {
+  logger.print("ExitCommand.execute()", "Executing exit command");
   if (cli.args.size() != 0) {
     cout << "INVALID COMMAND\n";
     return false;

--- a/Testshell/flush_command.cpp
+++ b/Testshell/flush_command.cpp
@@ -1,6 +1,7 @@
 #include "command.h"
 
 bool FlushCommand::execute(SSD_INTERFACE &ssd, const CommandLine &cli) {
+  logger.print("FlushCommand.execute()", "Executing flush command");
   if (cli.args.size() != 0) {
     cout << "INVALID COMMAND\n";
     return false;

--- a/Testshell/fullread_command.cpp
+++ b/Testshell/fullread_command.cpp
@@ -1,6 +1,7 @@
 #include "command.h"
 
 bool FullReadCommand::execute(SSD_INTERFACE &ssd, const CommandLine &cli) {
+  logger.print("FullReadCommand.execute()", "Executing full read command");
   if (cli.args.size() != 0) {
     cout << "INVALID COMMAND\n";
     return false;

--- a/Testshell/fullwrite_command.cpp
+++ b/Testshell/fullwrite_command.cpp
@@ -1,6 +1,7 @@
 #include "command.h"
 
 bool FullWriteCommand::execute(SSD_INTERFACE &ssd, const CommandLine &cli) {
+  logger.print("FullWriteCommand.execute()", "Executing full write command");
   if (cli.args.size() != 1) {
     std::cout << "INVALID COMMAND\n";
     return false;

--- a/Testshell/help_command.cpp
+++ b/Testshell/help_command.cpp
@@ -1,6 +1,7 @@
 #include "command.h"
 
 bool HelpCommand::execute(SSD_INTERFACE &ssd, const CommandLine &cli) {
+  logger.print("HelpCommand.execute()", "Executing help command");
   printHeader();
   printTeamInfo();
   printCommands();

--- a/Testshell/read_command.cpp
+++ b/Testshell/read_command.cpp
@@ -1,6 +1,7 @@
 #include "command.h"
 
 bool ReadCommand::execute(SSD_INTERFACE &ssd, const CommandLine &cli) {
+  logger.print("ReadCommand.execute()", "Executing read command");
   if (!isValidReadUsage(cli)) {
     cout << "INVALID COMMAND\n";
     return false;

--- a/Testshell/ssd_exe.cpp
+++ b/Testshell/ssd_exe.cpp
@@ -3,6 +3,7 @@
 using std::string;
 
 void SSD_EXE::read(int lba) {
+  logger.print("SSD_EXE.read()", "Reading LBA: " + std::to_string(lba));
   std::ostringstream cmd;
   cmd << "\"" << ssdDir << "\\" << SSD_EXE_NAME << "\" R " << lba;
 #ifdef _DEBUG
@@ -18,6 +19,8 @@ void SSD_EXE::read(int lba) {
 }
 
 void SSD_EXE::write(int lba, unsigned long value) {
+  logger.print("SSD_EXE.write()", "Writing LBA: " + std::to_string(lba) +
+                   " with value: " + std::to_string(value));
   std::ostringstream cmd;
   cmd << "\"" << ssdDir << "\\" << SSD_EXE_NAME << "\" W " << lba << " 0x"
       << std::hex << std::uppercase << value;
@@ -36,6 +39,8 @@ void SSD_EXE::write(int lba, unsigned long value) {
 }
 
 void SSD_EXE::erase(int lba, int size) {
+  logger.print("SSD_EXE.erase()", "Erasing LBA: " + std::to_string(lba) +
+                                      " with size: " + std::to_string(size));
   std::ostringstream cmd;
   cmd << "\"" << ssdDir << "\\" << SSD_EXE_NAME << "\" E " << lba << " "
       << size;
@@ -54,7 +59,8 @@ void SSD_EXE::erase(int lba, int size) {
 }
 
 
-  void SSD_EXE::flush() {
+void SSD_EXE::flush() {
+  logger.print("SSD_EXE.flush()", "Flushing SSD commands");
   std::ostringstream cmd;
   cmd << "\"" << ssdDir << "\\" << SSD_EXE_NAME << "\" F";
 #ifdef _DEBUG

--- a/Testshell/ssd_exe.h
+++ b/Testshell/ssd_exe.h
@@ -5,6 +5,7 @@
 #include <direct.h>
 
 #include "ssd_interface.h"
+#include "logger.h"
 
 using std::string;
 
@@ -24,6 +25,7 @@ private:
   const string SSD_EXE_NAME = "ssd.exe";
   const string SSD_OUTPUT_FILE = "ssd_output.txt";
   const string ERROR_MSG = "ERROR";
+  Logger &logger = Logger::getInstance();
 
   string getCurWorkingDir();
   string readOutputFile();

--- a/Testshell/test_script_command.cpp
+++ b/Testshell/test_script_command.cpp
@@ -1,11 +1,11 @@
 #include "command.h"
 
-bool checkPartialWriteSuccess(SSD_INTERFACE &ssd, int lba, unsigned long value) {
+bool checkPartialWriteSuccess(SSD_INTERFACE &ssd, int lba,
+                              unsigned long value) {
   ssd.read(lba);
 
   string valueStr = convertHexToString(value);
-  if (ssd.getResult() == "ERROR" ||
-      ssd.getResult() != valueStr) {
+  if (ssd.getResult() == "ERROR" || ssd.getResult() != valueStr) {
     return false;
   }
   return true;
@@ -20,13 +20,15 @@ bool preConditionCheck(const CommandLine &cli) {
 }
 
 bool TestScript1::execute(SSD_INTERFACE &ssd, const CommandLine &cli) {
+  logger.print("TestScript1.execute()",
+               "Executing full write and read compare test");
   if (!preConditionCheck(cli))
     return false;
 
   unsigned long value = 0xAAAABBBB;
   string valueStr = convertHexToString(value);
 
-if (!onExecute(ssd, value, valueStr))
+  if (!onExecute(ssd, value, valueStr))
     return false;
   return true;
 }
@@ -52,6 +54,8 @@ bool TestScript1::onExecute(SSD_INTERFACE &ssd, unsigned long value,
 }
 
 bool TestScript2::execute(SSD_INTERFACE &ssd, const CommandLine &cli) {
+  logger.print("TestScript2.execute()",
+               "Executing partial LBA write consistency test");
   if (!preConditionCheck(cli))
     return false;
 
@@ -72,8 +76,10 @@ bool TestScript2::execute(SSD_INTERFACE &ssd, const CommandLine &cli) {
 }
 
 bool TestScript3::execute(SSD_INTERFACE &ssd, const CommandLine &cli) {
+  logger.print("TestScript3.execute()", "Executing write/read aging test");
+
 #ifdef _DEBUG
-  unsigned long value = stoul(cli.args[0], nullptr, 16);
+  unsigned long value = stoul(cli.args[0], nullptr, HEX_BASE);
 #else
   if (!preConditionCheck(cli))
     return false;
@@ -98,8 +104,10 @@ bool TestScript3::execute(SSD_INTERFACE &ssd, const CommandLine &cli) {
 }
 
 bool TestScript4::execute(SSD_INTERFACE &ssd, const CommandLine &cli) {
+  logger.print("TestScript4.execute()", "Executing erase and write aging test");
   if (!preConditionCheck(cli))
     return false;
+
   unsigned long value1 = getRandomValue();
   unsigned long value2 = getRandomValue();
 

--- a/Testshell/test_shell.cpp
+++ b/Testshell/test_shell.cpp
@@ -1,4 +1,5 @@
 #include "test_shell.h"
+#include "logger.h"
 #include "gmock/gmock.h"
 
 void TestShell::run() {
@@ -15,7 +16,7 @@ void TestShell::runScripts() {
     CommandLine cli = commandHandler->parseCommand(script);
     if (!commandHandler->executeCommand(cli))
       break;
-    logger.print("TestShell.runScripts()", "Successfully executed script - " + script);
+    logger.print("TestShell.runScripts()", "Executed script: " + script);
   }
 }
 
@@ -24,14 +25,14 @@ void TestShell::runInteractive() {
   while (true) {
     cout << "> ";
     getline(std::cin, userInput);
+    logger.print("TestShell.runInteractive()", "User input: " + userInput);
     CommandLine cli = commandHandler->parseCommand(userInput);
-    logger.print("TestShell.runInteractive()",
-        "Successfully parsed command - " + cli.command);
     if (cli.command == "exit") {
       logger.print("TestShell.runInteractive()", "Exiting shell.");
       break;
     }
     commandHandler->executeCommand(cli);
-    logger.print("TestShell.runInteractive()", "Successfully executed command - " + cli.command);
+    logger.print("TestShell.runInteractive()",
+                 "Command executed: " + cli.command);
   }
 }

--- a/Testshell/write_command.cpp
+++ b/Testshell/write_command.cpp
@@ -1,6 +1,7 @@
 #include "command.h"
 
 bool WriteCommand::execute(SSD_INTERFACE &ssd, const CommandLine& cli) {
+  logger.print("WriteCommand.execute()", "Executing write command");
   if (!isValidWriteUsage(cli, HEX_BASE)) {
     cout << "INVALID COMMAND\n";
     return false;


### PR DESCRIPTION
## 📝 배경
> 어떤 기능이나 문제를 해결했나요?
- TestShell class에 logger가 직접적으로 포함되어있어서 다른 클래스에서 사용이 불가함

## 📝 세부 사항
> 세부 사항을 기록해주세요.
- TestShell class에서 logger 분리
- logger 다양한 함수에 추가

## 테스트 (write 명령어에 대한 로그 결과)
```
[25.07.10 14:22] TestShell.runInteractive()    : User input: write 5 abcd.
[25.07.10 14:22] CommandHandler.parseCommand() : Parsed command: write.
[25.07.10 14:22] WriteCommand.execute()        : Executing write command.
[25.07.10 14:22] SSD_EXE.write()               : Writing LBA: 5 with value: 43981.
[25.07.10 14:22] TestShell.runInteractive()    : Command executed: write.
```

## ✅ 체크리스트
다음 항목을 모두 만족하는 지 한번 더 확인 해주세요.
- [x] 코드 스타일 가이드에 맞게 작성함 (LLVM)
- [x] 최신 master를 merge하여 conflict를 해결함
- [x] 유닛 테스트를 모두 통과함
- [x] 배경 및 세부 사항을 적절히 기술함
