### PR TITLE
[bugfix] Add erase arg count valid check logic

### DIFF
--- a/Testshell/command.h
+++ b/Testshell/command.h
@@ -9,6 +9,8 @@
 #include "logger.h"
 #include "ssd_interface.h"
 
+#define interface class
+
 using std::cout;
 using std::endl;
 using std::string;
@@ -28,7 +30,7 @@ struct ShellExit : public std::exception {
 };
 
 // Abstract base class for command
-class ICommand {
+interface ICommand {
 public:
   ICommand() = default;  // Add default constructor
   virtual ~ICommand() = default;

--- a/Testshell/erase_command.cpp
+++ b/Testshell/erase_command.cpp
@@ -30,11 +30,16 @@ bool EraseCommand::execute(SSD_INTERFACE &ssd, const CommandLine &cli) {
 }
 
 bool EraseCommand::isValidEraseUsage(const CommandLine &cli) {
+  // 인자 개수 확인
+  if (cli.args.size() < 2) {
+    return false;
+  }
+  
   int lba, size;
   try {
     lba = std::stoi(cli.args[0]);
     size = std::stoi(cli.args[1]);
-  } catch (std::exception &e) {
+  } catch (std::exception &) {
     return false;
   }
 

--- a/Testshell/erase_range_command.cpp
+++ b/Testshell/erase_range_command.cpp
@@ -31,11 +31,15 @@ bool EraseRangeCommand::execute(SSD_INTERFACE &ssd, const CommandLine &cli) {
 }
 
 bool EraseRangeCommand::isValidEraseRangeUsage(const CommandLine &cli) {
+  if (cli.args.size() < 2) {
+    return false;
+  }
+  
   int st_lba, en_lba;
   try {
     st_lba = std::stoi(cli.args[0]);
     en_lba = std::stoi(cli.args[1]);
-  } catch (std::exception &e) {
+  } catch (std::exception &) {
     return false;
   }
 

--- a/Testshell/fullwrite_command.cpp
+++ b/Testshell/fullwrite_command.cpp
@@ -10,7 +10,7 @@ bool FullWriteCommand::execute(SSD_INTERFACE &ssd, const CommandLine &cli) {
   unsigned long value;
   try {
     value = std::stoul(cli.args[0], nullptr, HEX_BASE);
-  } catch (std::exception &e) {
+  } catch (std::exception &) {
     std::cout << "INVALID COMMAND\n";
     return false;
   }

--- a/Testshell/read_command.cpp
+++ b/Testshell/read_command.cpp
@@ -25,7 +25,7 @@ bool ReadCommand::isValidReadUsage(const CommandLine &cli) {
     return false;
   try {
     int lba = stoi(cli.args[0]);
-  } catch (std::exception &e) {
+  } catch (std::exception &) {
     return false;
   }
   return true;

--- a/Testshell/write_command.cpp
+++ b/Testshell/write_command.cpp
@@ -22,7 +22,7 @@ bool WriteCommand::isValidWriteUsage(const CommandLine &cli, int hexBase) {
   try {
     int lba = stoi(cli.args[0]);
     unsigned long value = stoul(cli.args[1], nullptr, hexBase);
-  } catch (std::exception &e) {
+  } catch (std::exception &) {
     return false;
   }
   return true;


### PR DESCRIPTION
## 📝 배경
> 어떤 기능이나 문제를 해결했나요?
- ```erase 111``` 같이 arg가 1개 이하일 경우 예외 처리가 안되고 종료되는 현상

## 📝 세부 사항
> 세부 사항을 기록해주세요.
- erase, erase_range에 arg 개수 검사 로직 추가

## ✅ 체크리스트
다음 항목을 모두 만족하는 지 한번 더 확인 해주세요.
- [x] 코드 스타일 가이드에 맞게 작성함 (LLVM)
- [x] 최신 master를 merge하여 conflict를 해결함
- [x] 유닛 테스트를 모두 통과함
- [x] 배경 및 세부 사항을 적절히 기술함
