### PR TITLE
[refact] strategy pattern

### DIFF
--- a/SSD/SSD.vcxproj
+++ b/SSD/SSD.vcxproj
@@ -127,6 +127,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="command_execute.cpp" />
     <ClCompile Include="file_iostream.cpp">
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'"> %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'"> %(AdditionalOptions)</AdditionalOptions>
@@ -166,6 +167,7 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="command.h" />
     <ClInclude Include="ssd_cmd_buffer.h" />
     <ClInclude Include="ssd_cmd_buffer_control.h" />
     <ClInclude Include="ssd_driver.h" />

--- a/SSD/command.h
+++ b/SSD/command.h
@@ -1,0 +1,46 @@
+#pragma once
+#include "ssd_cmd_buffer_control.h"
+class ICommand {
+public:
+  virtual void execute(int lba, int size, unsigned long value, char *argv[],
+                       CmdBufferControl &control) = 0;
+  virtual ~ICommand() = default;
+};
+
+class CommandAlgorithm {
+private:
+  std::unique_ptr<ICommand> currentCmd;
+
+public:
+  void selectCommand(std::unique_ptr <ICommand> cmd) {
+    currentCmd = std::move(cmd);
+  }
+  void execute(int lba, int size, unsigned long value, char *argv[],
+               CmdBufferControl &control) {
+    return currentCmd->execute(lba, size, value, argv, control);
+  }
+};
+
+class ReadCommand : public ICommand {
+public:
+  void execute(int lba, int size, unsigned long value, char *argv[],
+               CmdBufferControl &control);
+};
+
+class WriteCommand : public ICommand {
+public:
+  void execute(int lba, int size, unsigned long value, char *argv[],
+               CmdBufferControl &control);
+};
+
+class EraseCommand : public ICommand {
+public:
+  void execute(int lba, int size, unsigned long value, char *argv[],
+               CmdBufferControl &control);
+};
+
+class FlushCommand : public ICommand {
+public:
+  void execute(int lba, int size, unsigned long value, char *argv[],
+               CmdBufferControl &control);
+};

--- a/SSD/command_execute.cpp
+++ b/SSD/command_execute.cpp
@@ -1,0 +1,29 @@
+#include "command.h"
+
+void ReadCommand::execute(int lba, int size, unsigned long value, char *argv[],
+                          CmdBufferControl &control) {
+  unsigned long bufferRead = 0x0;
+
+  if (control.isBufferContainReadValue(lba, bufferRead))
+    control.getDriver()->readBuffer(lba, bufferRead);
+  else
+    control.getDriver()->read(lba);
+}
+
+void WriteCommand::execute(int lba, int size, unsigned long value, char *argv[],
+                           CmdBufferControl &control) {
+  unsigned long bufferRead = 0x0;
+
+  control.removeAndUpdateWriteCommand(lba, argv);
+}
+
+void EraseCommand::execute(int lba, int size, unsigned long value, char *argv[],
+                           CmdBufferControl &control) {
+  control.setEraseMap(lba, size, 1);
+  control.mergeAndUpdateEraseCommand(lba, size);
+}
+
+void FlushCommand::execute(int lba, int size, unsigned long value, char *argv[],
+                           CmdBufferControl &control) {
+  control.flush();
+}

--- a/SSD/ssd_cmd_buffer_control.h
+++ b/SSD/ssd_cmd_buffer_control.h
@@ -18,6 +18,7 @@ public:
   bool clearBufferByIndex(int index);
   void clearAllBuffer(void);
   void clearEraseMap();
+  void setEraseMap(int lba, int size, int setVal);
   bool flushEraseSeparated(int lba, int size);
   bool flush();
   bool isBufferFull() const;


### PR DESCRIPTION
## 📝 배경
> cmdbuffer 동작 알고리즘을 runtime에 cmd 종류에 따라 변경 가능하도록 전략패턴 사용
- 

## 📝 세부 사항
> 세부 사항을 기록해주세요.
- cmdbuffer 동작 알고리즘을 runtime에 cmd 종류에 따라 변경 가능하도록 전략패턴 사용

## ✅ 체크리스트
다음 항목을 모두 만족하는 지 한번 더 확인 해주세요.
- [x] 코드 스타일 가이드에 맞게 작성함 (LLVM)
- [x] 최신 master를 merge하여 conflict를 해결함
- [x] 유닛 테스트를 모두 통과함
- [x] 배경 및 세부 사항을 적절히 기술함
